### PR TITLE
Rename project to `data-driven-quad-control`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# data_driven_quad_control
+# data-driven-quad-control

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools >= 77.0.3"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "data_driven_quad_control"
+name = "data-driven-quad-control"
 version = "0.1.0"
 authors = [
   { name = "Pável A. Campos-Peña", email = "pcamposp@uni.pe" }
@@ -28,7 +28,7 @@ classifiers = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/pavelacamposp/data_driven_quad_control.git"
+Homepage = "https://github.com/pavelacamposp/data-driven-quad-control"
 
 [tool.setuptools]
 package-dir = {"" = "src"}


### PR DESCRIPTION
This PR renames the project from `data_driven_quad_control` to `data-driven-quad-control`. This improves the readability of the GitHub repository URL and aligns the project name with common Python package naming conventions.

### Key changes:
- Replaced `data_driven_quad_control` with `data-driven-quad-control` in `pyproject.toml` and `README.md`.
